### PR TITLE
Fixed the mismatched parameter and little code cleaning 

### DIFF
--- a/server/src/main/java/org/example/server/controller/ExerciseController.java
+++ b/server/src/main/java/org/example/server/controller/ExerciseController.java
@@ -3,6 +3,7 @@ package org.example.server.controller;
 import jakarta.validation.Valid;
 import org.example.server.dto.exerciseItem.ExerciseRequestDTO;
 import org.example.server.dto.exerciseItem.ExerciseResponseDTO;
+import org.example.server.model.DifficultyLevel;
 import org.example.server.service.ExerciseService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -61,7 +62,7 @@ public class ExerciseController {
 
     // Filtering
     @GetMapping("/difficulty/{level}")
-    public List<ExerciseResponseDTO> getExercisesByDifficulty(@PathVariable String level) {
+    public List<ExerciseResponseDTO> getExercisesByDifficulty(@PathVariable DifficultyLevel level) {
         return service.getExercisesByDifficulty(level);
     }
 

--- a/server/src/main/java/org/example/server/dto/exerciseItem/ExerciseRequestDTO.java
+++ b/server/src/main/java/org/example/server/dto/exerciseItem/ExerciseRequestDTO.java
@@ -1,7 +1,9 @@
 package org.example.server.dto.exerciseItem;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import org.example.server.model.DifficultyLevel;
 
 public record ExerciseRequestDTO(
 
@@ -16,8 +18,7 @@ public record ExerciseRequestDTO(
         @Size(max = 2000, message = "Description must be at most 2000 characters")
         String description,
 
-        @NotBlank(message = "Difficulty level is required")
-        @Size(max = 100, message = "Path must be at most 100 characters")
-                String difficultyLevel
+        @NotNull(message = "Difficulty level is required")
+        DifficultyLevel difficultyLevel
 ) {
 }

--- a/server/src/main/java/org/example/server/dto/exerciseItem/ExerciseResponseDTO.java
+++ b/server/src/main/java/org/example/server/dto/exerciseItem/ExerciseResponseDTO.java
@@ -1,5 +1,7 @@
 package org.example.server.dto.exerciseItem;
 
+import org.example.server.model.DifficultyLevel;
+
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -8,6 +10,6 @@ public record ExerciseResponseDTO(
         String title,
         String path,
         String description,
-        String difficultyLevel
+        DifficultyLevel difficultyLevel
 ) {}
 

--- a/server/src/main/java/org/example/server/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/org/example/server/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.net.URI;
 import java.time.LocalDateTime;
@@ -22,6 +23,31 @@ public class GlobalExceptionHandler {
         ProblemDetail problemDetail = ex.getBody();
         problemDetail.setInstance(URI.create(request.getRequestURI()));
         return problemDetail;
+    }
+
+    @ExceptionHandler(ExerciseNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleExerciseNotFoundException(ExerciseNotFoundException ex) {
+        ErrorResponse error = ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(HttpStatus.NOT_FOUND.value())
+                .error("Not Found")
+                .message(ex.getMessage())
+                .build();
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleTypeMismatchException(MethodArgumentTypeMismatchException ex) {
+        String message = String.format("Invalid value '%s' for parameter '%s'. Expected type: %s",
+                ex.getValue(), ex.getName(), ex.getRequiredType().getSimpleName());
+
+        ErrorResponse error = ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(HttpStatus.BAD_REQUEST.value())
+                .error("Bad Request")
+                .message(message)
+                .build();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/server/src/main/java/org/example/server/model/DifficultyLevel.java
+++ b/server/src/main/java/org/example/server/model/DifficultyLevel.java
@@ -1,0 +1,7 @@
+package org.example.server.model;
+
+public enum DifficultyLevel {
+    BEGINNER,
+    INTERMEDIATE,
+    ADVANCED
+}

--- a/server/src/main/java/org/example/server/model/Exercise.java
+++ b/server/src/main/java/org/example/server/model/Exercise.java
@@ -24,7 +24,8 @@ public class Exercise {
     private String description;
 
     @Column(nullable = false)
-    private String difficultyLevel;
+    @Enumerated(EnumType.STRING)
+    private DifficultyLevel difficultyLevel;
 
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -65,8 +66,8 @@ public class Exercise {
     public String getDescription() { return description; }
     public void setDescription(String description) { this.description = description; }
 
-    public String getDifficultyLevel() { return difficultyLevel; }
-    public void setDifficultyLevel(String description) { this.difficultyLevel = difficultyLevel; }
+    public DifficultyLevel getDifficultyLevel() { return difficultyLevel; }
+    public void setDifficultyLevel(DifficultyLevel difficultyLevel) { this.difficultyLevel = difficultyLevel; }
 
     public LocalDateTime getCreatedAt() {
         return createdAt;

--- a/server/src/main/java/org/example/server/repository/ExerciseRepository.java
+++ b/server/src/main/java/org/example/server/repository/ExerciseRepository.java
@@ -1,5 +1,6 @@
 package org.example.server.repository;
 
+import org.example.server.model.DifficultyLevel;
 import org.example.server.model.Exercise;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -15,14 +16,8 @@ public interface ExerciseRepository extends JpaRepository<Exercise, UUID> {
     Optional<Exercise> findByTitle(String title);
 
     // Returns Exercises by set difficulty level
-    List<Exercise> findByDifficultyLevel(String difficultyLevel);
+    List<Exercise> findByDifficultyLevel(DifficultyLevel difficultyLevel);
 
     // Returns all Exercises with a keyword in their title
     List<Exercise> findByTitleContainingIgnoreCase(String keyword);
-
-    // Returns all Exercises sorted by title (ASC)
-    List<Exercise> findAllByOrderByTitleAsc();
-
-    // Returns all Exercises sorted by creation date (createdAt DESC)
-    List<Exercise> findAllByOrderByCreatedAtDesc();
 }

--- a/server/src/main/java/org/example/server/service/ExerciseService.java
+++ b/server/src/main/java/org/example/server/service/ExerciseService.java
@@ -4,6 +4,7 @@ import org.example.server.dto.exerciseItem.ExerciseRequestDTO;
 import org.example.server.dto.exerciseItem.ExerciseResponseDTO;
 import org.example.server.exception.ExerciseNotFoundException;
 import org.example.server.mapper.ExerciseMapper;
+import org.example.server.model.DifficultyLevel;
 import org.example.server.model.Exercise;
 import org.example.server.repository.ExerciseRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,19 +41,6 @@ public class ExerciseService {
         return mapper.toResponse(updated);
     }
 
-    public ExerciseResponseDTO patchExercise(UUID id, ExerciseRequestDTO request) {
-        Exercise exercise = repository.findById(id)
-                .orElseThrow(() -> new ExerciseNotFoundException(id));
-
-        if (request.title() != null) exercise.setTitle(request.title());
-        if (request.path() != null) exercise.setPath(request.path());
-        if (request.description() != null) exercise.setDescription(request.description());
-        if (request.difficultyLevel() != null) exercise.setDifficultyLevel(request.difficultyLevel());
-
-        Exercise updated = repository.save(exercise);
-        return mapper.toResponse(updated);
-    }
-
     public void deleteExercise(UUID id) {
         if (!repository.existsById(id)) throw new ExerciseNotFoundException(id);
         repository.deleteById(id);
@@ -77,7 +65,7 @@ public class ExerciseService {
         return exercises.map(mapper::toResponse);
     }
 
-    public List<ExerciseResponseDTO> getExercisesByDifficulty(String difficultyLevel) {
+    public List<ExerciseResponseDTO> getExercisesByDifficulty(DifficultyLevel difficultyLevel) {
         return repository.findByDifficultyLevel(difficultyLevel).stream()
                 .map(mapper::toResponse)
                 .collect(Collectors.toList());


### PR DESCRIPTION
This pull request refactors the handling of exercise difficulty levels throughout the backend by introducing a `DifficultyLevel` enum and updating all related code to use this type instead of plain strings. It also improves exception handling for invalid difficulty level values and missing exercises. These changes make the codebase more type-safe and robust.

**Difficulty Level Refactor:**

* Introduced a new `DifficultyLevel` enum in `org.example.server.model` and updated the `Exercise` entity to use this enum for the `difficultyLevel` field, including JPA annotations for proper persistence. 
* Updated `ExerciseRequestDTO` and `ExerciseResponseDTO` to use the `DifficultyLevel` enum instead of a string, and adjusted validation annotations accordingly. 
* Modified the repository method `findByDifficultyLevel` and related service/controller methods to use the enum type, ensuring type safety across the application. 
**Exception Handling Improvements:**

* Added a global exception handler for `ExerciseNotFoundException` and for `MethodArgumentTypeMismatchException` (e.g., when an invalid difficulty level is provided in the URL), returning appropriate error responses to the client.

**Code Cleanup:**

* Removed unused or redundant repository methods for sorting and paging exercises, streamlining the repository interface.
* Removed the unused `patchExercise` method from the service layer, as part of the refactor.