### PR TITLE
Feature: Added limitation on the awarded try on the quizes

### DIFF
--- a/server/src/main/java/org/example/server/service/QuizService.java
+++ b/server/src/main/java/org/example/server/service/QuizService.java
@@ -70,6 +70,10 @@ public class QuizService {
                 return new ResourceNotFoundException("Child not found");
             });
 
+        // Check if child has previously passed this quiz
+        List<QuizAttempt> previousAttempts = quizAttemptRepository.findByChildIdAndQuizId(childId, quizId);
+        boolean hasPassedBefore = previousAttempts.stream().anyMatch(QuizAttempt::getPassed);
+
         Map<UUID, String> answers = request.answers();
         int totalQuestions = quiz.getQuestions().size();
         int correctAnswers = 0;
@@ -83,12 +87,16 @@ public class QuizService {
 
         int scorePercent = totalQuestions == 0 ? 0 : Math.round((float) correctAnswers / totalQuestions * 100);
         boolean passed = scorePercent >= quiz.getPassPercent();
-        int pocketMoneyAwarded = passed ? (correctAnswers * quiz.getPocketMoneyPerQuestion()) : 0;
 
-        if (passed && pocketMoneyAwarded > 0) {
+        // Only award pocket money if this is the first time passing
+        int pocketMoneyAwarded = (passed && !hasPassedBefore) ? (correctAnswers * quiz.getPocketMoneyPerQuestion()) : 0;
+
+        if (pocketMoneyAwarded > 0) {
             child.setPocketMoney(child.getPocketMoney() + pocketMoneyAwarded);
             childRepository.save(child);
             log.info("Awarded {} pocket money to child {}", pocketMoneyAwarded, childId);
+        } else if (passed && hasPassedBefore) {
+            log.info("Child {} passed quiz {} again, but no pocket money awarded (already passed before)", childId, quizId);
         }
 
         QuizAttempt attempt = new QuizAttempt(
@@ -105,9 +113,14 @@ public class QuizService {
         log.info("Quiz attempt saved - Score: {}/{} ({}%), Passed: {}, Awarded: {}",
             correctAnswers, totalQuestions, scorePercent, passed, pocketMoneyAwarded);
 
-        String message = passed
-            ? "Congrats! You passed the quiz."
-            : "You did not pass. Try again.";
+        String message;
+        if (passed && hasPassedBefore) {
+            message = "Great job! You passed again, but pocket money was already awarded on your first pass.";
+        } else if (passed) {
+            message = "Congrats! You passed the quiz.";
+        } else {
+            message = "You did not pass. Try again.";
+        }
 
         return new QuizSubmitResponseDTO(
             totalQuestions,

--- a/server/src/test/java/org/example/server/service/QuizServiceTest.java
+++ b/server/src/test/java/org/example/server/service/QuizServiceTest.java
@@ -254,4 +254,58 @@ class QuizServiceTest {
     verify(quizRepository).deleteById(quizId);
     verify(quizAttemptRepository, never()).deleteAll(any());
   }
+
+  @Test
+  void submitQuiz_RetakeAfterPassing_NoMoneyAwarded() {
+    UUID questionId = testQuiz.getQuestions().get(0).getId();
+    Map<UUID, String> answers = Map.of(questionId, "a"); // Correct answer
+
+    // Create a previous passing attempt
+    QuizAttempt previousAttempt = new QuizAttempt(testQuiz, testChild, 1, 1, 100, true, 10);
+    List<QuizAttempt> previousAttempts = Arrays.asList(previousAttempt);
+
+    QuizSubmitRequestDTO request = new QuizSubmitRequestDTO(answers);
+
+    when(quizRepository.findById(quizId)).thenReturn(Optional.of(testQuiz));
+    when(childRepository.findById(childId)).thenReturn(Optional.of(testChild));
+    when(quizAttemptRepository.findByChildIdAndQuizId(childId, quizId)).thenReturn(previousAttempts);
+    when(quizAttemptRepository.save(any(QuizAttempt.class))).thenAnswer(i -> i.getArguments()[0]);
+
+    QuizSubmitResponseDTO result = quizService.submitQuiz(quizId, childId, request);
+
+    assertNotNull(result);
+    assertTrue(result.passed());
+    assertEquals(100, result.percent());
+    assertEquals(0, result.awarded()); // No money awarded on retake
+    assertTrue(result.message().contains("already awarded"));
+    verify(childRepository, never()).save(any(Child.class)); // No money transaction
+    verify(quizAttemptRepository).save(any(QuizAttempt.class)); // But attempt is still recorded
+  }
+
+  @Test
+  void submitQuiz_RetakeAfterFailing_MoneyAwardedIfPassed() {
+    UUID questionId = testQuiz.getQuestions().get(0).getId();
+    Map<UUID, String> answers = Map.of(questionId, "a"); // Correct answer
+
+    // Create a previous failing attempt
+    QuizAttempt previousAttempt = new QuizAttempt(testQuiz, testChild, 1, 0, 0, false, 0);
+    List<QuizAttempt> previousAttempts = Arrays.asList(previousAttempt);
+
+    QuizSubmitRequestDTO request = new QuizSubmitRequestDTO(answers);
+
+    when(quizRepository.findById(quizId)).thenReturn(Optional.of(testQuiz));
+    when(childRepository.findById(childId)).thenReturn(Optional.of(testChild));
+    when(quizAttemptRepository.findByChildIdAndQuizId(childId, quizId)).thenReturn(previousAttempts);
+    when(childRepository.save(any(Child.class))).thenReturn(testChild);
+    when(quizAttemptRepository.save(any(QuizAttempt.class))).thenAnswer(i -> i.getArguments()[0]);
+
+    QuizSubmitResponseDTO result = quizService.submitQuiz(quizId, childId, request);
+
+    assertNotNull(result);
+    assertTrue(result.passed());
+    assertEquals(100, result.percent());
+    assertEquals(10, result.awarded()); // Money awarded on first pass
+    verify(childRepository).save(any(Child.class)); // Money transaction occurs
+    verify(quizAttemptRepository).save(any(QuizAttempt.class));
+  }
 }


### PR DESCRIPTION
This pull request updates the quiz submission logic to ensure that pocket money is only awarded the first time a child passes a quiz, and not on subsequent retakes. It also adds new tests to verify this behavior. The changes improve both the business logic and test coverage around quiz retakes and rewards.

**Quiz reward logic updates:**

* Updated `QuizService.submitQuiz` to check if the child has previously passed the quiz, and only award pocket money on the first successful attempt. Subsequent passes do not grant additional rewards, and an appropriate message is returned. 
**Test coverage improvements:**

* Added two new tests in `QuizServiceTest`:
  - `submitQuiz_RetakeAfterPassing_NoMoneyAwarded`: Verifies that no pocket money is awarded if the child passes a quiz again after already passing it once.
  - `submitQuiz_RetakeAfterFailing_MoneyAwardedIfPassed`: Verifies that if a child failed previously but passes on a retake, pocket money is awarded as expected.